### PR TITLE
Select All in topic view, file size display, sort, and UI polish (#4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -747,7 +747,7 @@
     You'll receive a <code>.zip</code> file — you can upload it directly, or extract it and upload the <code>conversations.json</code> file(s) inside.<br>
     <strong>Your data never leaves your browser.</strong>
   </p>
-  <p style="font-size:.72rem;color:#bbb;margin-top:1.5rem;">v2 · 2026-03-20 12:47</p>
+  <p style="font-size:.72rem;color:#bbb;margin-top:1.5rem;">v2.1 · 2026-03-31 13:38</p>
 </div>
 
 <!-- ── Dashboard ──────────────────────────────────────────────────────────── -->
@@ -950,7 +950,7 @@
 <footer>
   <span>Built by <a href="https://substack.com/@alyssafuward" target="_blank" rel="noopener">Alyssa Fu Ward</a></span>
   <span class="footer-divider">·</span>
-  <span>v2 · 2026-03-20 12:47</span>
+  <span>v2.1 · 2026-03-31 13:38</span>
 </footer>
 
 <!-- ── Conversation drawer ────────────────────────────────────────────────── -->


### PR DESCRIPTION
## Summary
- Select All / Deselect All button in topic conversation list
- File size per conversation in Marked for Download tab
- Sort dropdown (Pinned order / Largest first / Smallest first)
- Stacked date + topic metadata layout in download list
- Filled accent-colored pin icons in tab and intro text
- ← All topics restored above topic header; Topics tab also navigates back
- Version bumped to v2.1 · 2026-03-31

🤖 Generated with [Claude Code](https://claude.com/claude-code)