### PR TITLE
Add merge-with-dedup upload flow — add to existing data or replace

### DIFF
--- a/index.html
+++ b/index.html
@@ -2728,7 +2728,8 @@ document.getElementById('export-data-btn').addEventListener('click', () => {
 });
 
 document.getElementById('export-topics-btn').addEventListener('click', () => {
-  downloadJSON(TOPICS, 'chatgpt_explorer_topics.json');
+  const exportable = Object.entries(TOPICS).map(([topic, keywords]) => ({ topic, keywords }));
+  downloadJSON(exportable, 'chatgpt_explorer_topics.json');
 });
 
 function downloadJSON(data, filename) {


### PR DESCRIPTION
## Summary
- When data is already loaded and new files are uploaded, a dialog asks: **Add to existing data** or **Replace everything**
- "Add" merges and deduplicates by `create_time + title` — uploading the same export twice won't double your conversations
- Pinned (marked for download) conversations are preserved across merges via `_key` matching
- "Replace" is the previous behavior — clears everything and rebuilds
- Reset button renamed from "← Load new files" to "← Add / manage files"

## Test plan
- [ ] Upload a zip — loads normally with no dialog (no existing data)
- [ ] With data loaded, drop another file — dialog appears with conversation count
- [ ] Choose "Add" — new conversations appear, no duplicates if same file uploaded
- [ ] Choose "Replace" — data is fully replaced
- [ ] Choose "Cancel" — nothing changes
- [ ] Pin some conversations, then merge new files — pins are still there after merge
- [ ] "Add / manage files" button in header returns to upload screen correctly

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)