### PR TITLE
Add count labels above bars on Conversations per Month chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -1985,6 +1985,24 @@ function renderMonthlyChart(monthlyCounts) {
   const data   = labels.map(l => monthlyCounts[l]);
   const max    = Math.max(...data);
 
+  const barLabelPlugin = {
+    id: 'barLabels',
+    afterDatasetsDraw(chart) {
+      const { ctx, data: d, scales: { x, y } } = chart;
+      ctx.save();
+      ctx.font = '600 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      d.datasets[0].data.forEach((val, i) => {
+        if (!val) return;
+        const bar = chart.getDatasetMeta(0).data[i];
+        ctx.fillStyle = '#888';
+        ctx.fillText(val, bar.x, bar.y - 4);
+      });
+      ctx.restore();
+    }
+  };
+
   if (monthlyChart) monthlyChart.destroy();
   monthlyChart = new Chart(document.getElementById('monthly-chart'), {
     type: 'bar',
@@ -1997,6 +2015,7 @@ function renderMonthlyChart(monthlyCounts) {
         borderSkipped: false,
       }]
     },
+    plugins: [barLabelPlugin],
     options: {
       responsive: true,
       maintainAspectRatio: false,


### PR DESCRIPTION
Draws the conversation count above each bar using a Chart.js afterDatasetsDraw plugin — no external dependencies.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)