### PR TITLE
Rename app to AI Chat Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ChatGPT Explorer
+# AI Chat Explorer
 
 **Created by [Alyssa Fu Ward](https://substack.com/@alyssafuward)**
 
-A browser-based tool for exploring your ChatGPT conversation history. Upload your exported data and instantly get a searchable, visual breakdown of everything you've talked about — organized by topic, mapped across time, and fully readable.
+A browser-based tool for exploring your AI conversation history — ChatGPT, Claude, and more. Upload your exported data and instantly get a searchable, visual breakdown of everything you've talked about — organized by topic, mapped across time, and fully readable.
 
 **Your data never leaves your browser.** All processing happens locally. Nothing is sent to any server.
 
@@ -10,12 +10,12 @@ A browser-based tool for exploring your ChatGPT conversation history. Upload you
 
 ## Features
 
-- **Overview** — monthly conversation volume (click any bar to browse that month) and topic breakdown charts
+- **Overview** — monthly conversation volume (click any bar to browse that month) and topic breakdown charts; stacked by AI source when multiple are loaded
 - **Topics** — auto-classified conversations grouped into themes; click any topic to browse conversations, click any conversation to read the full thread
 - **Search** — full-text search across titles and message content with highlighted snippets
 - **Timeline** — line chart showing how your topics shifted month by month; click any data point to see the conversations behind it
-- **ChatGPT Me** — extract your side of every conversation (your messages only) into a file you can hand to any AI to build a personal profile or mine your history
-- **Marked for Download** — pin conversations and download them individually or as a ZIP
+- **AI Chat Me** — extract your side of every conversation (your messages only) into a file you can hand to any AI to build a personal profile or mine your history
+- **Pinned for Download** — pin conversations and download them individually or as a ZIP
 
 Your data is saved in the browser between sessions using IndexedDB. You can upload multiple exports and merge them — duplicates are automatically deduplicated.
 
@@ -23,23 +23,23 @@ Your data is saved in the browser between sessions using IndexedDB. You can uplo
 
 ## How to Use
 
-### 1. Export your ChatGPT data
+### 1. Export your data
 
-In ChatGPT: **Settings → Data Controls → Export Data**
+**ChatGPT:** Settings → Data Controls → Export Data → you'll receive a `.zip` file by email.
 
-You'll receive an email with a `.zip` file.
+**Claude:** Settings → Privacy → Export Data → you'll receive a `conversations.json` file.
 
 ### 2. Open the app
 
 Open `index.html` directly in any modern browser — no installation, no server needed.
 
-Or visit the hosted version at: https://alyssafuward.github.io/chatgpt-explorer/
+Or visit the hosted version at: https://alyssafuward.github.io/ai-chat-explorer/
 
 ### 3. Upload your files
 
-Drag and drop your `.zip` export directly onto the upload area — no extraction needed. The app will find and process all `conversations.json` files inside automatically.
+Drag and drop your `.zip` or `.json` export onto the upload area. The app will find and process all conversation files automatically.
 
-You can also upload extracted JSON files individually: either a single `conversations.json` or multiple numbered files (`conversations-000.json`, `conversations-001.json`, etc.). Multiple files are supported.
+You can upload ChatGPT and Claude exports together — they'll be parsed correctly and labeled separately with source filter chips and colored badges.
 
 If you already have data saved in the browser, you'll be asked whether to merge the new files in or replace everything.
 
@@ -60,8 +60,8 @@ No build step, no dependencies to install, no server required.
 ## Cloning & Developing
 
 ```bash
-git clone https://github.com/alyssafuward/chatgpt-explorer.git
-cd chatgpt-explorer
+git clone https://github.com/alyssafuward/ai-chat-explorer.git
+cd ai-chat-explorer
 open index.html
 ```
 
@@ -125,9 +125,9 @@ The app does not include a CSP header or meta tag. A CSP would provide an additi
 
 #### ⚠️ No JSON schema validation
 
-The app performs basic structural checks on uploaded JSON (`c && c.create_time`) but does not validate the full schema of the ChatGPT export format. A malformed or unexpected JSON structure will fail silently — conversations with missing fields are skipped rather than crashing the app.
+The app performs basic structural checks on uploaded JSON but does not validate the full schema of the export format. A malformed or unexpected JSON structure will fail silently — conversations with missing fields are skipped rather than crashing the app.
 
-**Risk level:** Low. The app is designed for a specific, well-known export format. Silent failure on unexpected input is preferable to a confusing crash.
+**Risk level:** Low. The app is designed for well-known export formats. Silent failure on unexpected input is preferable to a confusing crash.
 
 ### Threat model summary
 
@@ -144,7 +144,7 @@ The app performs basic structural checks on uploaded JSON (`c && c.create_time`)
 
 This review covers the `index.html` file as of v2 (2026-03-20). It does not cover:
 - Forks or modifications made after cloning
-- The security of ChatGPT's export format itself
+- The security of ChatGPT's or Claude's export format itself
 - Browser-level vulnerabilities or extensions
 - The hosting environment (GitHub Pages, Netlify, etc.)
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ChatGPT Explorer</title>
+  <title>AI Chat Explorer</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=DM+Serif+Display&display=swap" rel="stylesheet">
@@ -1184,7 +1184,7 @@
 <!-- ── Upload screen ──────────────────────────────────────────────────────── -->
 
 <div id="upload-screen">
-  <h1>ChatGPT Explorer</h1>
+  <h1>AI Chat Explorer</h1>
   <p class="byline">by <a href="https://substack.com/@alyssafuward" target="_blank" rel="noopener">Alyssa Fu Ward</a></p>
   <p class="subtitle">Upload your ChatGPT export and explore your conversations — what you talked about, when, and how your topics shifted over time.</p>
 
@@ -1208,7 +1208,7 @@
 
 <div id="dashboard">
   <header>
-    <h1>ChatGPT Explorer</h1>
+    <h1>AI Chat Explorer</h1>
     <span id="header-range"></span>
     <div id="header-right">
       <span id="save-status-pill"></span>
@@ -1282,7 +1282,7 @@
   </div>
 
   <div class="intro-block" style="padding-left:2rem;padding-right:2rem;max-width:1100px;margin:0 auto;">
-    <h2>Welcome to ChatGPT Explorer</h2>
+    <h2>Welcome to AI Chat Explorer</h2>
     <p>This tool gives you a bird's-eye view of everything you've talked about with ChatGPT — organized by topic, searchable by keyword, and mapped across time. Pin conversations to mark them for download. Use the tabs below to explore.</p>
   </div>
 
@@ -2986,7 +2986,7 @@ async function downloadAllMarked() {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = 'chatgpt_conversations.zip';
+  a.download = 'ai_chat_conversations.zip';
   a.click();
   URL.revokeObjectURL(url);
 }
@@ -3452,7 +3452,7 @@ function refreshSettingsUI() {
 
 // ── IndexedDB ─────────────────────────────────────────────────────────────────
 
-const DB_NAME = 'chatgpt-explorer';
+const DB_NAME = 'ai-chat-explorer';
 const DB_VERSION = 1;
 
 function getDB() {
@@ -3691,12 +3691,12 @@ document.getElementById('export-data-btn').addEventListener('click', () => {
     topic: c.topic,
     messages: c.messages
   }));
-  downloadJSON(exportable, 'chatgpt_conversations.json');
+  downloadJSON(exportable, 'ai_chat_conversations.json');
 });
 
 document.getElementById('export-topics-btn').addEventListener('click', () => {
   const exportable = Object.entries(TOPICS).map(([topic, keywords]) => ({ topic, keywords }));
-  downloadJSON(exportable, 'chatgpt_explorer_topics.json');
+  downloadJSON(exportable, 'ai_chat_explorer_topics.json');
 });
 
 function downloadJSON(data, filename) {
@@ -3817,9 +3817,9 @@ At the end, synthesize this into a **Personal System Prompt** — a short paragr
 function buildProfileCoverMessage() {
   return `I've attached two files:
 
-1. chatgpt-profile-data.txt — my ChatGPT conversation history, filtered to show only my messages (not the AI responses), plus all conversation titles.
+1. ai-chat-profile-data.txt — my AI conversation history, filtered to show only my messages (not the AI responses), plus all conversation titles.
 
-2. chatgpt-profile-prompt.txt — instructions for what I'd like you to do with this data.
+2. ai-chat-profile-prompt.txt — instructions for what I'd like you to do with this data.
 
 Please read both files and follow the instructions in the prompt file.`;
 }
@@ -3868,7 +3868,7 @@ function downloadProfileData() {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = 'chatgpt-profile-data.txt';
+  a.download = 'ai-chat-profile-data.txt';
   a.click();
   URL.revokeObjectURL(url);
 }
@@ -3879,7 +3879,7 @@ function downloadProfilePrompt() {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = 'chatgpt-profile-prompt.txt';
+  a.download = 'ai-chat-profile-prompt.txt';
   a.click();
   URL.revokeObjectURL(url);
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chatgpt-explorer",
+  "name": "ai-chat-explorer",
   "version": "1.0.0",
   "description": "**Created by [Alyssa Fu Ward](https://substack.com/@alyssafuward)**",
   "main": "index.js",
@@ -8,16 +8,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alyssafuward/chatgpt-explorer.git"
+    "url": "git+https://github.com/alyssafuward/ai-chat-explorer.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "bugs": {
-    "url": "https://github.com/alyssafuward/chatgpt-explorer/issues"
+    "url": "https://github.com/alyssafuward/ai-chat-explorer/issues"
   },
-  "homepage": "https://github.com/alyssafuward/chatgpt-explorer#readme",
+  "homepage": "https://github.com/alyssafuward/ai-chat-explorer#readme",
   "devDependencies": {
     "@playwright/test": "^1.58.2"
   }


### PR DESCRIPTION
## Summary

- Renames all user-facing text from "ChatGPT Explorer" → "AI Chat Explorer"
- Updates exported file names (`ai_chat_conversations.zip`, `ai_chat_conversations.json`, etc.)
- Updates IndexedDB store name (`ai-chat-explorer`) — note: existing saved data will need to be re-uploaded once after this change
- Updates README to reflect multi-source support (ChatGPT + Claude) and new repo URL
- Updates `package.json` name and URLs

GitHub repo rename follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)